### PR TITLE
Add slow fall effect to cloud armor

### DIFF
--- a/Heaven-Pass/Heaven-Pass/src/main/java/com/owoskree07/heaven/armor/CustomArmorItem.java
+++ b/Heaven-Pass/Heaven-Pass/src/main/java/com/owoskree07/heaven/armor/CustomArmorItem.java
@@ -1,0 +1,63 @@
+package com.owoskree07.heaven.armor;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.EquipmentSlotType;
+import net.minecraft.item.ArmorItem;
+import net.minecraft.item.IArmorMaterial;
+import net.minecraft.item.ItemStack;
+import net.minecraft.potion.Effect;
+import net.minecraft.potion.EffectInstance;
+import net.minecraft.world.World;
+
+public abstract class CustomArmorItem extends ArmorItem
+{
+	private EffectInstance armorEffect;
+	private final Effect armorEffectType;
+	private final boolean isTickSlot;
+	private final Class<?> itemClass;
+
+	public CustomArmorItem(IArmorMaterial materialIn, EquipmentSlotType slot, Properties builder)
+	{
+		super(materialIn, slot, builder);
+		this.armorEffect = getEffectInstance();
+		this.armorEffectType = armorEffect.getPotion();
+		this.isTickSlot = slot == EquipmentSlotType.FEET;
+		this.itemClass = getItemClass();
+	}
+
+	@Override
+	public void onArmorTick (final ItemStack stack, final World world, final PlayerEntity player)
+	{
+		if (!isTickSlot || !hasFullArmor(itemClass, player))
+			return;
+
+		giveEffect(player);
+	}
+
+	abstract public EffectInstance getEffectInstance();
+
+	abstract public Class<?> getItemClass();
+
+	private void giveEffect(final PlayerEntity player)
+	{
+		EffectInstance playerEff = player.getActivePotionEffect(this.armorEffectType);
+		if (playerEff == null)
+			player.addPotionEffect(this.armorEffect);
+		else if (playerEff.getAmplifier() > 1 && playerEff.getDuration() <= 1)
+		{
+			this.armorEffect = getEffectInstance();
+			player.addPotionEffect(this.armorEffect);
+		}
+	}
+
+	private static boolean hasFullArmor (final Class<?> armorType, final PlayerEntity player)
+	{
+		Iterable<ItemStack> armorList = player.getArmorInventoryList();
+		for(ItemStack stack : armorList){
+			if (stack.getItem().getClass() != armorType){
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/Heaven-Pass/Heaven-Pass/src/main/java/com/owoskree07/heaven/armor/cloud/cloudArmorItem.java
+++ b/Heaven-Pass/Heaven-Pass/src/main/java/com/owoskree07/heaven/armor/cloud/cloudArmorItem.java
@@ -1,0 +1,27 @@
+package com.owoskree07.heaven.armor.cloud;
+
+import com.owoskree07.heaven.armor.CustomArmorItem;
+import net.minecraft.inventory.EquipmentSlotType;
+import net.minecraft.item.IArmorMaterial;
+import net.minecraft.potion.EffectInstance;
+import net.minecraft.potion.Effects;
+
+public class cloudArmorItem extends CustomArmorItem
+{
+	public cloudArmorItem (IArmorMaterial materialIn, EquipmentSlotType slot, Properties builder)
+	{
+		super(materialIn, slot, builder);
+	}
+
+	@Override
+	public Class getItemClass()
+	{
+		return this.getClass();
+	}
+
+	@Override
+	public EffectInstance getEffectInstance()
+	{
+		return new EffectInstance(Effects.SLOW_FALLING, 0, 0, false, false);
+	}
+}

--- a/Heaven-Pass/Heaven-Pass/src/main/java/com/owoskree07/heaven/init/ModItems.java
+++ b/Heaven-Pass/Heaven-Pass/src/main/java/com/owoskree07/heaven/init/ModItems.java
@@ -69,16 +69,16 @@ public class ModItems {
             () -> new ArmorItem(ModArmorMaterial.SUN, EquipmentSlotType.FEET, new Item.Properties().group(ExampleMod.TAB)));
 
     public static final RegistryObject<ArmorItem> CLOUD_HELMET = ITEMS.register("cloud_helmet",
-            () -> new ArmorItem(ModArmorMaterial.CLOUD, EquipmentSlotType.HEAD, new Item.Properties().group(ExampleMod.TAB)));
+            () -> new cloudArmorItem(ModArmorMaterial.CLOUD, EquipmentSlotType.HEAD, new Item.Properties().group(ExampleMod.TAB)));
 
     public static final RegistryObject<ArmorItem> CLOUD_CHESTPLATE = ITEMS.register("cloud_chestplate",
-            () -> new ArmorItem(ModArmorMaterial.CLOUD, EquipmentSlotType.CHEST, new Item.Properties().group(ExampleMod.TAB)));
+            () -> new cloudArmorItem(ModArmorMaterial.CLOUD, EquipmentSlotType.CHEST, new Item.Properties().group(ExampleMod.TAB)));
 
     public static final RegistryObject<ArmorItem> CLOUD_LEGGINGS = ITEMS.register("cloud_leggings",
-            () -> new ArmorItem(ModArmorMaterial.CLOUD, EquipmentSlotType.LEGS, new Item.Properties().group(ExampleMod.TAB)));
+            () -> new cloudArmorItem(ModArmorMaterial.CLOUD, EquipmentSlotType.LEGS, new Item.Properties().group(ExampleMod.TAB)));
 
     public static final RegistryObject<ArmorItem> CLOUD_BOOTS = ITEMS.register("cloud_boots",
-            () -> new ArmorItem(ModArmorMaterial.CLOUD, EquipmentSlotType.FEET, new Item.Properties().group(ExampleMod.TAB)));
+            () -> new cloudArmorItem(ModArmorMaterial.CLOUD, EquipmentSlotType.FEET, new Item.Properties().group(ExampleMod.TAB)));
 
 
     // Block Items


### PR DESCRIPTION
Add a the new class CustomArmorItem which checks if the full set is on and gives the effect. This class has two abstract methods: getItemclass() and getArmorEffect() these are the methods which are individual for every armor. To use the CustomArmorItem class add a new class for each armor which extends the CustomArmorClass and override the abstract methods. In the getItemClass() return this.getClass() and in the getArmorEffec() return the effect you want the armor to have. To avoid maintaning the wrong amplifier when the player wears full set while giving itself slow fall with a higher amplifier, the CustomArmorItem class holds a if/else statement to check for this case and then giving a new EffectInstance.